### PR TITLE
Remove all Intriguer execution folders.

### DIFF
--- a/intriguer_afl/afl-fuzz.c
+++ b/intriguer_afl/afl-fuzz.c
@@ -5368,11 +5368,6 @@ static u8 fuzz_one(char** argv) {
     // printf("cmd: %s\n", cmd);
     system(cmd);
     ck_free(cmd);
-
-    cmd = alloc_printf("rm -r %s", temp_dir);
-
-    system(cmd);
-    ck_free(cmd);
   }
 
   if(queue_cur->fields == NULL)
@@ -5381,6 +5376,10 @@ static u8 fuzz_one(char** argv) {
   ck_free(field_name);
   ck_free(fname);
 
+  u8 *cmd = alloc_printf("rm -r %s", temp_dir);
+
+  system(cmd);
+  ck_free(cmd); 
 
   /*********************
    * PERFORMANCE SCORE *


### PR DESCRIPTION
**Goal:** Remove all Intriguer execution folders. 

Dear Intriguer Team,
some of the temporary folders created for Intriguer execution are not removed.

It is harmless for short fuzzing sessions but quickly fill your disk space for long ones.
This is because:
- the execution temporary folder is created [before intriguer is checking for the fileds](https://github.com/seclab-yonsei/intriguer/blob/master/intriguer_afl/afl-fuzz.c#L5341),
- but only removed within the true branch.

The PR only pushes the code removing those folders after the branch.

thank you for your great job,
Best